### PR TITLE
Remove isFilterable function override

### DIFF
--- a/tampermonkey.user.js
+++ b/tampermonkey.user.js
@@ -12,12 +12,6 @@
 (function(window) {
     var $ = window.$, _ = window._, TD = window.TD, _gaq = window._gaq;
 
-    var oldIsFilterable = TD.vo.Column.prototype.isFilterable;
-    TD.vo.Column.prototype.isFilterable = _.wrap(oldIsFilterable, function (func) {
-        if (this.getColumnType() === 'col_unknown') return true;
-        return func.call(this);
-    });
-
     TD.services.TwitterClient.prototype.getTrendsCustom = function(params, success, error) {
         this.makeTwitterCall(
             this.API_BASE_URL+"trends/place.json",


### PR DESCRIPTION
Remove the override of `isFilterable` function on the column prototype. Internally this was calling `getColumnType` - another function on the column prototype that TD seems to have removed recently. I couldn't find any obvious replacement for `getColumnType` and the script seemed to work when this function override was removed.